### PR TITLE
Build updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack-cli": "3.2.1"
   },
   "peerDependencies": {
-    "react": ">=15.0.0",
+    "react": ">=15.5.0",
     "prop-types": ">=15.5.7"
   },
   "files": [

--- a/scripts/prebuild.sh
+++ b/scripts/prebuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-VERSION="$(node scripts/version.js $(git describe --long --tags))"
+VERSION="$(scripts/version.sh $(git describe --long --tags))"
 
 echo "Building ${npm_package_name}@$VERSION"

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="$(node scripts/version.js $(git describe --long --tags))"
+VERSION="$(scripts/version.sh $(git describe --long --tags))"
 
 echo "Updating package.json"
 

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,5 +1,0 @@
-const REGEX = new RegExp('^v([0-9]*)\.([0-9]*)\.[0-9]*-([0-9]*)-(.*)$');
-const MATCH = REGEX.exec(process.argv[2]);
-const VERSION = `${MATCH[1]}.${MATCH[2]}.${MATCH[3]}`;
-
-console.log(VERSION);

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# regex the output from `git describe --long` (e.g. v0.0.0-4-gd8bff40)
+[[ $1 =~ ^v([0-9]*)\.([0-9]*)\.[0-9]*-([0-9]*)-(.*)$ ]]
+
+# Parse each version component (or '0' if regex match failed)
+MAJOR="${BASH_REMATCH[1]}"
+if [[ -z "$MAJOR" ]]; then
+   MAJOR="0"
+fi
+
+MINOR="${BASH_REMATCH[2]}"
+if [[ -z "$MINOR" ]]; then
+   MINOR="0"
+fi
+
+REVISION="${BASH_REMATCH[3]}"
+if [[ -z "$REVISION" ]]; then
+   REVISION="0"
+fi
+
+echo "${MAJOR}.${MINOR}.${REVISION}"


### PR DESCRIPTION
Converted version generation script to bash (since all other build scripts are bash), providing default version number values if `git describe --long` fails for whatever reason.

React peer dependency updated to 15.5.0 to coincide with its separate from `prop-types`